### PR TITLE
Fix CI & move to pytest

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -49,7 +49,7 @@ jobs:
           cd deploy
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install freezegun fakeredis
+          python -m pip install freezegun fakeredis pytest pytest-django
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run posthog tests
@@ -63,7 +63,7 @@ jobs:
           touch frontend/dist/index.html
           touch frontend/dist/layout.html
           touch frontend/dist/shared_dashboard.html
-          python manage.py test posthog -v 2 --exclude-tag=skip_on_multitenancy
+          pytest posthog/ -m "not skip_on_multitenancy"
 
       - name: Run EE tests
         env:
@@ -76,7 +76,7 @@ jobs:
           CLICKHOUSE_VERIFY: "False"
         run: |
           cd deploy
-          python manage.py test ee
+          pytest ee/
 
   cloud:
     name: Local repository tests
@@ -122,7 +122,7 @@ jobs:
           cd deploy
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install freezegun fakeredis
+          python -m pip install freezegun fakeredis pytest pytest-django
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Check migrations
@@ -150,4 +150,4 @@ jobs:
           touch frontend/dist/index.html
           touch frontend/dist/layout.html
           touch frontend/dist/shared_dashboard.html
-          python manage.py test multi_tenancy messaging -v 2 --exclude-tag=skip_on_multitenancy
+          pytest multi_tenancy messaging -m "not skip_on_multitenancy"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -109,8 +109,8 @@ jobs:
       - name: Fetch posthog main repo
         run: |
           bin/pull_main
-          cp deploy/ee/conftest.py messaging/conftest.py
-          cp deploy/ee/conftest.py multi_tenancy/conftest.py
+          cp deploy/ee/conftest.py deploy/messaging/conftest.py
+          cp deploy/ee/conftest.py deploy/multi_tenancy/conftest.py
 
       - name: Set up dependencies caching
         uses: actions/cache@v2

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -107,7 +107,10 @@ jobs:
           python-version: "3.8"
 
       - name: Fetch posthog main repo
-        run: bin/pull_main
+        run: |
+          bin/pull_main
+          cp deploy/ee/conftest.py messaging/conftest.py
+          cp deploy/ee/conftest.py multi_tenancy/conftest.py
 
       - name: Set up dependencies caching
         uses: actions/cache@v2


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/3417 switched the way we run tests to use `pytest`. Particularly, this switch changed the way we set up the CH DB which was causing our local tests to fail because the CH was not set up. This PR fixes that and moves this repo to use pytest too in the CI.

For future reference, it's important to remember to update this PR too when changing the way we run tests in the main repo.