### PR TITLE
Set default payment method on Stripe after card registration

### DIFF
--- a/multi_tenancy/stripe.py
+++ b/multi_tenancy/stripe.py
@@ -27,19 +27,17 @@ def _get_customer_id(customer_id: str, email: str = "") -> str:
 
 
 def set_default_payment_method_for_customer(customer_id: str, payment_method_id: str) -> bool:
+    _init_stripe()
     return (
         stripe.Customer.modify(
-            customer_id, {"invoice_settings": {"default_payment_method": payment_method_id}}
-        ).invoice_settings["default_payment_method"]
+            customer_id, invoice_settings={"default_payment_method": payment_method_id}
+        ).invoice_settings.default_payment_method
         == payment_method_id
     )
 
 
 def create_subscription_checkout_session(
-    email: str,
-    base_url: str,
-    price_id: str = "",
-    customer_id: str = "",
+    email: str, base_url: str, price_id: str = "", customer_id: str = "",
 ) -> Tuple[str, str]:
     """
     Creates a checkout session for a billing subscription (used by flat-fee recurring subscriptions)
@@ -66,29 +64,15 @@ def create_subscription_checkout_session(
     return (session.id, customer_id)
 
 
-def create_zero_auth(
-    email: str,
-    base_url: str,
-    customer_id: str = "",
-) -> Tuple[str, str]:
+def create_zero_auth(email: str, base_url: str, customer_id: str = "",) -> Tuple[str, str]:
 
     customer_id = _get_customer_id(customer_id, email)
 
     payload: Dict = {
         "payment_method_types": ["card"],
-        "line_items": [
-            {
-                "amount": 50,
-                "quantity": 1,
-                "currency": "USD",
-                "name": "Card authorization",
-            },
-        ],
+        "line_items": [{"amount": 50, "quantity": 1, "currency": "USD", "name": "Card authorization",},],
         "mode": "payment",
-        "payment_intent_data": {
-            "capture_method": "manual",
-            "statement_descriptor": "POSTHOG PREAUTH",
-        },
+        "payment_intent_data": {"capture_method": "manual", "statement_descriptor": "POSTHOG PREAUTH",},
         "customer": customer_id,
         "success_url": base_url + "billing/welcome?session_id={CHECKOUT_SESSION_ID}",
         "cancel_url": base_url + "billing/failed?session_id={CHECKOUT_SESSION_ID}",
@@ -99,10 +83,7 @@ def create_zero_auth(
     return (session.id, customer_id)
 
 
-def create_subscription(
-    price_id: str = "",
-    customer_id: str = "",
-) -> Tuple[str, str]:
+def create_subscription(price_id: str = "", customer_id: str = "",) -> Tuple[str, str]:
     """
     Creates a subscription for an existing customer with payment details already set up. Used mainly for metered
     plans.
@@ -142,26 +123,16 @@ def customer_portal_url(customer_id: str) -> Optional[str]:
 def parse_webhook(payload: Union[bytes, str], signature: str) -> Dict:
 
     if not settings.STRIPE_WEBHOOK_SECRET:
-        raise ImproperlyConfigured(
-            "Cannot process billing webhook because env vars are not properly set.",
-        )
+        raise ImproperlyConfigured("Cannot process billing webhook because env vars are not properly set.",)
 
-    return stripe.Webhook.construct_event(
-        payload,
-        signature,
-        settings.STRIPE_WEBHOOK_SECRET,
-    )
+    return stripe.Webhook.construct_event(payload, signature, settings.STRIPE_WEBHOOK_SECRET,)
 
 
 def compute_webhook_signature(payload: str, secret: str) -> str:
     return stripe.webhook.WebhookSignature._compute_signature(payload, secret)
 
 
-def report_subscription_item_usage(
-    subscription_item_id: str,
-    billed_usage: int,
-    timestamp: datetime.datetime,
-) -> bool:
+def report_subscription_item_usage(subscription_item_id: str, billed_usage: int, timestamp: datetime.datetime,) -> bool:
     _init_stripe()
 
     # The idempotency_key is the combination of the subscription ID and current timestamp, as we should only report

--- a/multi_tenancy/tests/cassettes/test_billing_period_special_handling_for_startup_plan
+++ b/multi_tenancy/tests/cassettes/test_billing_period_special_handling_for_startup_plan
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: invoice_settings[default_payment_method]=card_1IRjpiEuIatRXSdzMcSSmCU9
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '70'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Stripe/v1 PythonBindings/2.56.0
+    method: POST
+    uri: https://api.stripe.com/v1/customers/cus_IuiXChYGDqmHPi
+  response:
+    body:
+      string: "{\n  \"id\": \"cus_IuiXChYGDqmHPi\",\n  \"object\": \"customer\",\n
+        \ \"address\": null,\n  \"balance\": 0,\n  \"created\": 1612865177,\n  \"currency\":
+        \"usd\",\n  \"default_source\": \"card_1IRjpXEuIatRXSdzpIgBfsUP\",\n  \"delinquent\":
+        false,\n  \"description\": null,\n  \"discount\": null,\n  \"email\": \"test@posthog.com\",\n
+        \ \"invoice_prefix\": \"43C36A24\",\n  \"invoice_settings\": {\n    \"custom_fields\":
+        null,\n    \"default_payment_method\": \"card_1IRjpiEuIatRXSdzMcSSmCU9\",\n
+        \   \"footer\": null\n  },\n  \"livemode\": false,\n  \"metadata\": {\n  },\n
+        \ \"name\": null,\n  \"next_invoice_sequence\": 2,\n  \"phone\": null,\n  \"preferred_locales\":
+        [\n\n  ],\n  \"shipping\": null,\n  \"sources\": {\n    \"object\": \"list\",\n
+        \   \"data\": [\n      {\n        \"id\": \"card_1IRjpXEuIatRXSdzpIgBfsUP\",\n
+        \       \"object\": \"card\",\n        \"address_city\": null,\n        \"address_country\":
+        \"US\",\n        \"address_line1\": null,\n        \"address_line1_check\":
+        null,\n        \"address_line2\": null,\n        \"address_state\": null,\n
+        \       \"address_zip\": null,\n        \"address_zip_check\": null,\n        \"brand\":
+        \"Visa\",\n        \"country\": \"US\",\n        \"customer\": \"cus_IuiXChYGDqmHPi\",\n
+        \       \"cvc_check\": \"pass\",\n        \"dynamic_last4\": null,\n        \"exp_month\":
+        4,\n        \"exp_year\": 2022,\n        \"fingerprint\": \"JybBXF60SmPa2ZpU\",\n
+        \       \"funding\": \"credit\",\n        \"last4\": \"4242\",\n        \"metadata\":
+        {\n        },\n        \"name\": null,\n        \"tokenization_method\": null\n
+        \     },\n      {\n        \"id\": \"card_1IRjpiEuIatRXSdzMcSSmCU9\",\n        \"object\":
+        \"card\",\n        \"address_city\": null,\n        \"address_country\": null,\n
+        \       \"address_line1\": null,\n        \"address_line1_check\": null,\n
+        \       \"address_line2\": null,\n        \"address_state\": null,\n        \"address_zip\":
+        null,\n        \"address_zip_check\": null,\n        \"brand\": \"Visa\",\n
+        \       \"country\": \"US\",\n        \"customer\": \"cus_IuiXChYGDqmHPi\",\n
+        \       \"cvc_check\": \"pass\",\n        \"dynamic_last4\": null,\n        \"exp_month\":
+        4,\n        \"exp_year\": 2024,\n        \"fingerprint\": \"JybBXF60SmPa2ZpU\",\n
+        \       \"funding\": \"credit\",\n        \"last4\": \"4242\",\n        \"metadata\":
+        {\n        },\n        \"name\": null,\n        \"tokenization_method\": null\n
+        \     }\n    ],\n    \"has_more\": false,\n    \"total_count\": 2,\n    \"url\":
+        \"/v1/customers/cus_IuiXChYGDqmHPi/sources\"\n  },\n  \"subscriptions\": {\n
+        \   \"object\": \"list\",\n    \"data\": [\n      {\n        \"id\": \"sub_J2i9v9VdhWbjju\",\n
+        \       \"object\": \"subscription\",\n        \"application_fee_percent\":
+        null,\n        \"billing_cycle_anchor\": 1614708845,\n        \"billing_thresholds\":
+        null,\n        \"cancel_at\": null,\n        \"cancel_at_period_end\": false,\n
+        \       \"canceled_at\": null,\n        \"collection_method\": \"charge_automatically\",\n
+        \       \"created\": 1614708845,\n        \"current_period_end\": 1617387245,\n
+        \       \"current_period_start\": 1614708845,\n        \"customer\": \"cus_IuiXChYGDqmHPi\",\n
+        \       \"days_until_due\": null,\n        \"default_payment_method\": null,\n
+        \       \"default_source\": null,\n        \"default_tax_rates\": [\n\n        ],\n
+        \       \"discount\": null,\n        \"ended_at\": null,\n        \"items\":
+        {\n          \"object\": \"list\",\n          \"data\": [\n            {\n
+        \             \"id\": \"si_J2i9eUttdXoSlA\",\n              \"object\": \"subscription_item\",\n
+        \             \"billing_thresholds\": null,\n              \"created\": 1614708846,\n
+        \             \"metadata\": {\n              },\n              \"plan\": {\n
+        \               \"id\": \"price_1IIt6eEuIatRXSdz0WhjQeI2\",\n                \"object\":
+        \"plan\",\n                \"active\": true,\n                \"aggregate_usage\":
+        \"sum\",\n                \"amount\": null,\n                \"amount_decimal\":
+        null,\n                \"billing_scheme\": \"tiered\",\n                \"created\":
+        1612865164,\n                \"currency\": \"usd\",\n                \"interval\":
+        \"month\",\n                \"interval_count\": 1,\n                \"livemode\":
+        false,\n                \"metadata\": {\n                },\n                \"nickname\":
+        null,\n                \"product\": \"prod_IuiXiNy8CGzEj7\",\n                \"tiers\":
+        [\n                  {\n                    \"flat_amount\": null,\n                    \"flat_amount_decimal\":
+        null,\n                    \"unit_amount\": null,\n                    \"unit_amount_decimal\":
+        \"0.05\",\n                    \"up_to\": 1000\n                  },\n                  {\n
+        \                   \"flat_amount\": null,\n                    \"flat_amount_decimal\":
+        null,\n                    \"unit_amount\": 1,\n                    \"unit_amount_decimal\":
+        \"1\",\n                    \"up_to\": null\n                  }\n                ],\n
+        \               \"tiers_mode\": \"graduated\",\n                \"transform_usage\":
+        null,\n                \"trial_period_days\": null,\n                \"usage_type\":
+        \"metered\"\n              },\n              \"price\": {\n                \"id\":
+        \"price_1IIt6eEuIatRXSdz0WhjQeI2\",\n                \"object\": \"price\",\n
+        \               \"active\": true,\n                \"billing_scheme\": \"tiered\",\n
+        \               \"created\": 1612865164,\n                \"currency\": \"usd\",\n
+        \               \"livemode\": false,\n                \"lookup_key\": null,\n
+        \               \"metadata\": {\n                },\n                \"nickname\":
+        null,\n                \"product\": \"prod_IuiXiNy8CGzEj7\",\n                \"recurring\":
+        {\n                  \"aggregate_usage\": \"sum\",\n                  \"interval\":
+        \"month\",\n                  \"interval_count\": 1,\n                  \"trial_period_days\":
+        null,\n                  \"usage_type\": \"metered\"\n                },\n
+        \               \"tiers_mode\": \"graduated\",\n                \"transform_quantity\":
+        null,\n                \"type\": \"recurring\",\n                \"unit_amount\":
+        null,\n                \"unit_amount_decimal\": null\n              },\n              \"subscription\":
+        \"sub_J2i9v9VdhWbjju\",\n              \"tax_rates\": [\n\n              ]\n
+        \           }\n          ],\n          \"has_more\": false,\n          \"total_count\":
+        1,\n          \"url\": \"/v1/subscription_items?subscription=sub_J2i9v9VdhWbjju\"\n
+        \       },\n        \"latest_invoice\": \"in_1IQcjREuIatRXSdzPq5XJFsQ\",\n
+        \       \"livemode\": false,\n        \"metadata\": {\n        },\n        \"next_pending_invoice_item_invoice\":
+        null,\n        \"pause_collection\": null,\n        \"pending_invoice_item_interval\":
+        null,\n        \"pending_setup_intent\": null,\n        \"pending_update\":
+        null,\n        \"plan\": {\n          \"id\": \"price_1IIt6eEuIatRXSdz0WhjQeI2\",\n
+        \         \"object\": \"plan\",\n          \"active\": true,\n          \"aggregate_usage\":
+        \"sum\",\n          \"amount\": null,\n          \"amount_decimal\": null,\n
+        \         \"billing_scheme\": \"tiered\",\n          \"created\": 1612865164,\n
+        \         \"currency\": \"usd\",\n          \"interval\": \"month\",\n          \"interval_count\":
+        1,\n          \"livemode\": false,\n          \"metadata\": {\n          },\n
+        \         \"nickname\": null,\n          \"product\": \"prod_IuiXiNy8CGzEj7\",\n
+        \         \"tiers\": [\n            {\n              \"flat_amount\": null,\n
+        \             \"flat_amount_decimal\": null,\n              \"unit_amount\":
+        null,\n              \"unit_amount_decimal\": \"0.05\",\n              \"up_to\":
+        1000\n            },\n            {\n              \"flat_amount\": null,\n
+        \             \"flat_amount_decimal\": null,\n              \"unit_amount\":
+        1,\n              \"unit_amount_decimal\": \"1\",\n              \"up_to\":
+        null\n            }\n          ],\n          \"tiers_mode\": \"graduated\",\n
+        \         \"transform_usage\": null,\n          \"trial_period_days\": null,\n
+        \         \"usage_type\": \"metered\"\n        },\n        \"quantity\": 1,\n
+        \       \"schedule\": null,\n        \"start_date\": 1614708845,\n        \"status\":
+        \"active\",\n        \"tax_percent\": null,\n        \"transfer_data\": null,\n
+        \       \"trial_end\": null,\n        \"trial_start\": null\n      }\n    ],\n
+        \   \"has_more\": false,\n    \"total_count\": 1,\n    \"url\": \"/v1/customers/cus_IuiXChYGDqmHPi/subscriptions\"\n
+        \ },\n  \"tax_exempt\": \"none\",\n  \"tax_ids\": {\n    \"object\": \"list\",\n
+        \   \"data\": [\n\n    ],\n    \"has_more\": false,\n    \"total_count\":
+        0,\n    \"url\": \"/v1/customers/cus_IuiXChYGDqmHPi/tax_ids\"\n  }\n}\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7863'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      access-control-max-age:
+      - '300'
+      cache-control:
+      - no-cache, no-store
+      stripe-should-retry:
+      - 'false'
+      stripe-version:
+      - '2020-03-02'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/multi_tenancy/tests/test_webhooks.py
+++ b/multi_tenancy/tests/test_webhooks.py
@@ -466,6 +466,7 @@ class TestPaymentSucceededWebhooks(StripeWebhookTestMixin):
 class TestSpecialWebhookHandling(StripeWebhookTestMixin):
     @patch("posthoganalytics.capture")
     @patch("multi_tenancy.views.cancel_payment_intent")
+    @vcr.use_cassette(cassette_library_dir="multi_tenancy/tests/cassettes", filter_headers=["authorization"])
     def test_billing_period_special_handling_for_startup_plan(
         self, cancel_payment_intent, mock_capture,
     ):
@@ -475,11 +476,11 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
         organization, _, user1 = self.create_org_team_user()
         user2 = User.objects.create_user(email="test_user_2@posthog.com", first_name="Test 2", password="12345678")
         user2.join(organization=organization)
-        startup_plan = Plan.objects.create(key="startup", name="Startup", price_id="not_set",)
+        startup_plan = Plan.objects.create(key="startup", name="Startup", price_id="not_set")
         instance: OrganizationBilling = OrganizationBilling.objects.create(
             organization=organization,
             should_setup_billing=True,
-            stripe_customer_id="cus_I2maGIMVxJI",
+            stripe_customer_id="cus_IuiXChYGDqmHPi",
             plan=startup_plan,
         )
 
@@ -513,8 +514,9 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
                     "confirmation_method":"automatic",
                     "created":1600267775,
                     "currency":"usd",
-                    "customer":"cus_I2maGIMVxJI",
-                    "on_behalf_of":null
+                    "customer":"cus_IuiXChYGDqmHPi",
+                    "on_behalf_of":null,
+                    "payment_method": "card_1IRjpiEuIatRXSdzMcSSmCU9"
                 }
             },
             "livemode":false,
@@ -524,7 +526,7 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
         """
 
         signature: str = self.generate_webhook_signature(body, sample_webhook_secret)
-        csrf_client = Client(enforce_csrf_checks=True,)  # Custom client to ensure CSRF checks pass
+        csrf_client = Client(enforce_csrf_checks=True)  # Custom client to ensure CSRF checks pass
 
         with self.settings(STRIPE_WEBHOOK_SECRET=sample_webhook_secret):
 
@@ -563,8 +565,9 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
     @patch("multi_tenancy.stripe._get_customer_id")
     @patch("multi_tenancy.stripe.stripe.Subscription.create")
     @patch("multi_tenancy.views.cancel_payment_intent")
+    @patch("multi_tenancy.stripe.set_default_payment_method_for_customer")
     def test_handle_webhook_for_metered_plans_after_card_registration(
-        self, cancel_payment_intent, mock_session_create, mock_customer_id, mock_capture,
+        self, set_default_pm, cancel_payment_intent, mock_session_create, mock_customer_id, mock_capture,
     ):
         sample_webhook_secret: str = "wh_sec_test_abcdefghijklmnopqrstuvwxyz"
         mock_customer_id.return_value = "cus_MeteredI2MVxJI"
@@ -613,7 +616,8 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
                     "created":1600267775,
                     "currency":"usd",
                     "customer":"cus_MeteredI2MVxJI",
-                    "on_behalf_of":null
+                    "on_behalf_of":null,
+                    "payment_method": "pm_iEuIaI2h3ETxMVtRXS"
                 }
             },
             "livemode":false,
@@ -656,6 +660,8 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
             "billing card validated",
             {"plan_key": "metered", "billing_period_ends": None, "organization_id": str(organization.id)},
         )
+
+        set_default_pm.assert_called_once_with("cus_MeteredI2MVxJI", "pm_iEuIaI2h3ETxMVtRXS")
 
     @patch("multi_tenancy.views.capture_exception")
     def test_webhook_with_invalid_signature_fails(self, capture_exception):

--- a/multi_tenancy/tests/test_webhooks.py
+++ b/multi_tenancy/tests/test_webhooks.py
@@ -565,7 +565,7 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
     @patch("multi_tenancy.stripe._get_customer_id")
     @patch("multi_tenancy.stripe.stripe.Subscription.create")
     @patch("multi_tenancy.views.cancel_payment_intent")
-    @patch("multi_tenancy.stripe.set_default_payment_method_for_customer")
+    @patch("stripe.Customer.modify")
     def test_handle_webhook_for_metered_plans_after_card_registration(
         self, set_default_pm, cancel_payment_intent, mock_session_create, mock_customer_id, mock_capture,
     ):
@@ -661,7 +661,9 @@ class TestSpecialWebhookHandling(StripeWebhookTestMixin):
             {"plan_key": "metered", "billing_period_ends": None, "organization_id": str(organization.id)},
         )
 
-        set_default_pm.assert_called_once_with("cus_MeteredI2MVxJI", "pm_iEuIaI2h3ETxMVtRXS")
+        set_default_pm.assert_called_once_with(
+            "cus_MeteredI2MVxJI", invoice_settings={"default_payment_method": "pm_iEuIaI2h3ETxMVtRXS"}
+        )
 
     @patch("multi_tenancy.views.capture_exception")
     def test_webhook_with_invalid_signature_fails(self, capture_exception):

--- a/multi_tenancy/views.py
+++ b/multi_tenancy/views.py
@@ -20,14 +20,11 @@ from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from sentry_sdk import capture_exception, capture_message
 
 import stripe
-from multi_tenancy.tasks import (report_card_validated,
-                                 update_subscription_billing_period)
+from multi_tenancy.tasks import report_card_validated, update_subscription_billing_period
 
 from .models import OrganizationBilling, Plan
-from .serializers import (BillingSubscribeSerializer,
-                          MultiTenancyOrgSignupSerializer, PlanSerializer)
-from .stripe import (cancel_payment_intent, customer_portal_url, parse_webhook,
-                     set_default_payment_method_for_customer)
+from .serializers import BillingSubscribeSerializer, MultiTenancyOrgSignupSerializer, PlanSerializer
+from .stripe import cancel_payment_intent, customer_portal_url, parse_webhook, set_default_payment_method_for_customer
 from .utils import get_cached_monthly_event_usage
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-stripe==2.48.0
+stripe==2.56.0
 vcrpy==4.1.1 # tests only


### PR DESCRIPTION
Everytime a new card is added for future usage (`mode = setup`), we automatically set that card as the default payment method for subscriptions on Stripe.

Previously this was causing a billing issue in which customers in usage-based pricing plans weren't billed after their initial period and/or trial elapsed because Stripe didn't have any "default" payment method on file. More context on [this thread](https://posthog.slack.com/archives/C01P3BQ1LFL/p1614689260000500)

This PR also upgrades Stripe library to the latest version.
