### PR TITLE
Make sure ph_current_project_name is latin-1-safe

### DIFF
--- a/multi_tenancy/middleware.py
+++ b/multi_tenancy/middleware.py
@@ -39,7 +39,7 @@ class PostHogTokenCookieMiddleware(SessionMiddleware):
 
             response.set_cookie(
                 key="ph_current_project_name",  # clarify which project is active (orgs can have multiple projects)
-                value=request.user.team.name,
+                value=request.user.team.name.encode('utf-8').decode('latin-1'),
                 max_age=365 * 24 * 60 * 60,
                 expires=default_cookie_options["expires"],
                 path=default_cookie_options["path"],


### PR DESCRIPTION
Fixes error preventing Cloud from working for users if their current project has a non-Latin-1-compatible character.
Reported by a user on Slack.