### PR TITLE
Fix signup tests

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -49,7 +49,7 @@ jobs:
           cd deploy
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install freezegun fakeredis pytest pytest-django
+          python -m pip install freezegun fakeredis pytest pytest_mock pytest-django
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run posthog tests

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -98,9 +98,10 @@ class TestTeamSignup(TransactionBaseTest):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response.data.pop('detail') # Message might be changed in main repo
         self.assertEqual(
-            response.data,
-            {"type": "validation_error", "code": "unique", "detail": "Email already in use.", "attr": "email",},
+            response.data["type"]
+            {"type": "validation_error", "code": "unique", "attr": "email",},
         )
 
     @patch("posthoganalytics.capture")

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -98,10 +98,9 @@ class TestTeamSignup(TransactionBaseTest):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        response.data.pop('detail') # Message might be changed in main repo
+        response.data.pop("detail")  # Message might be changed in main repo
         self.assertEqual(
-            response.data["type"]
-            {"type": "validation_error", "code": "unique", "attr": "email",},
+            response.data["type"], {"type": "validation_error", "code": "unique", "attr": "email"},
         )
 
     @patch("posthoganalytics.capture")

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -100,7 +100,7 @@ class TestTeamSignup(TransactionBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         response.data.pop("detail")  # Message might be changed in main repo
         self.assertEqual(
-            response.data["type"], {"type": "validation_error", "code": "unique", "attr": "email"},
+            response.data, {"type": "validation_error", "code": "unique", "attr": "email"},
         )
 
     @patch("posthoganalytics.capture")


### PR DESCRIPTION
- PR stops expecting a specific error response when an account is being created with a duplicate email as this message can change in the main repo.
- PR also adds missing dependency for tests on `pytest_mock` that was introduced in https://github.com/PostHog/posthog/pull/3705

Friendly reminder if we introduce new test dependencies in the main repo to update posthog-cloud too.