### PR TITLE
Match EE premium features on Cloud

### DIFF
--- a/multi_tenancy/models.py
+++ b/multi_tenancy/models.py
@@ -4,17 +4,17 @@ from typing import List, Optional, Tuple
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
+from ee.models import License
 from posthog.models import Organization, User
-from posthog.templatetags.posthog_filters import compact_number
 
 from .stripe import create_subscription, create_subscription_checkout_session, create_zero_auth
 
 PLANS = {
     "starter": ["organizations_projects"],
-    "growth": ["zapier", "organizations_projects"],
-    "startup": ["zapier", "organizations_projects"],
-    "standard": ["zapier", "organizations_projects"],
-    "enterprise": ["zapier", "organizations_projects"],
+    "growth": License.ENTERPRISE_FEATURES,
+    "startup": License.ENTERPRISE_FEATURES,
+    "standard": License.ENTERPRISE_FEATURES,
+    "enterprise": License.ENTERPRISE_FEATURES,
 }
 
 

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -120,22 +120,25 @@ class TestOrganizationBilling(BaseTest, PlanTestMixin):
         # Startup plan
         plan.key = "startup"
         plan.save()
-        self.assertEqual(billing.available_features, ["zapier", "organizations_projects"])
+        self.assertIn("organizations_projects", billing.available_features)
+        self.assertIn("zapier", billing.available_features)
 
         # Growth plan
         plan.key = "growth"
         plan.save()
-        self.assertEqual(billing.available_features, ["zapier", "organizations_projects"])
+        self.assertIn("organizations_projects", billing.available_features)
 
         # Standard plan
         plan.key = "standard"
         plan.save()
-        self.assertEqual(billing.available_features, ["zapier", "organizations_projects"])
+        self.assertIn("organizations_projects", billing.available_features)
+        self.assertIn("zapier", billing.available_features)
 
         # Enterprise plan
         plan.key = "enterprise"
         plan.save()
-        self.assertEqual(billing.available_features, ["zapier", "organizations_projects"])
+        self.assertIn("organizations_projects", billing.available_features)
+        self.assertIn("zapier", billing.available_features)
 
     def test_feature_available_multi_tenancy(self):
         organization, _, _ = self.create_org_team_user()


### PR DESCRIPTION
This PR matches premium features for EE `enterprise` plan to all paid plans on cloud (except legacy Starter) so we don't have to update posthog-cloud every time this list changes. We might change this behavior in the future if plans diverge, but for now we're matching all features.