### PR TITLE
User V2 Cloud Refactor

### DIFF
--- a/multi_tenancy/serializers.py
+++ b/multi_tenancy/serializers.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from messaging.tasks import process_organization_signup_messaging
 from posthog.api.organization import OrganizationSignupSerializer
 from posthog.models import User
-from posthog.templatetags.posthog_filters import compact_number
 from rest_framework import serializers
 from sentry_sdk import capture_exception
 
@@ -65,11 +64,56 @@ class PlanSerializer(ReadOnlySerializer):
 
 
 class BillingSerializer(serializers.ModelSerializer):
+    plan = PlanSerializer(read_only=True)
+    current_usage = serializers.SerializerMethodField()
+    subscription_url = serializers.SerializerMethodField()
+
     class Meta:
         model = OrganizationBilling
         fields = [
+            "should_setup_billing",
+            "is_billing_active",
             "plan",
+            "billing_period_ends",
+            "event_allocation",
+            "current_usage",
+            "subscription_url",
         ]
+
+    def get_current_usage(self, instance: OrganizationBilling) -> Optional[int]:
+        try:
+            return get_cached_monthly_event_usage(instance.organization)
+        except Exception as e:
+            capture_exception(e)
+        return None
+
+    def get_subscription_url(self, instance: OrganizationBilling) -> Optional[str]:
+        request = self.context["request"]
+        checkout_session = None
+        if instance.should_setup_billing and not instance.is_billing_active:
+            if (
+                instance.stripe_checkout_session
+                and instance.checkout_session_created_at
+                and instance.checkout_session_created_at + timezone.timedelta(minutes=1439) > timezone.now()
+            ):
+                # Checkout session has been created and is still active (i.e. created less than 24 hours ago)
+                checkout_session = instance.stripe_checkout_session
+            else:
+                try:
+                    (checkout_session, customer_id) = instance.create_checkout_session(
+                        user=request.user, base_url=request.build_absolute_uri("/"),
+                    )
+                except ImproperlyConfigured as e:
+                    capture_exception(e)
+                else:
+                    if checkout_session:
+                        OrganizationBilling.objects.filter(pk=instance.pk).update(
+                            stripe_checkout_session=checkout_session,
+                            stripe_customer_id=customer_id,
+                            checkout_session_created_at=timezone.now(),
+                        )
+
+        return f"/billing/setup?session_id={checkout_session}" if checkout_session else None
 
 
 class BillingSubscribeSerializer(serializers.Serializer):

--- a/multi_tenancy/serializers.py
+++ b/multi_tenancy/serializers.py
@@ -10,6 +10,7 @@ from rest_framework import serializers
 from sentry_sdk import capture_exception
 
 from .models import OrganizationBilling, Plan
+from .utils import get_cached_monthly_event_usage
 
 
 class ReadOnlySerializer(serializers.ModelSerializer):
@@ -63,6 +64,14 @@ class PlanSerializer(ReadOnlySerializer):
         ]
 
 
+class BillingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OrganizationBilling
+        fields = [
+            "plan",
+        ]
+
+
 class BillingSubscribeSerializer(serializers.Serializer):
     """
     Serializer allowing a user to set up billing information.
@@ -111,4 +120,3 @@ class BillingSubscribeSerializer(serializers.Serializer):
 
     def to_representation(self, instance):
         return instance
-

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -41,6 +41,7 @@ class TestTeamSignup(CloudAPIBaseTest):
             response.data,
             {
                 "id": user.pk,
+                "uuid": str(user.uuid),
                 "distinct_id": user.distinct_id,
                 "first_name": "John",
                 "email": "hedgehog@posthog.com",
@@ -249,6 +250,7 @@ class TestTeamSignup(CloudAPIBaseTest):
             response.data,
             {
                 "id": user.pk,
+                "uuid": str(user.uuid),
                 "distinct_id": user.distinct_id,
                 "first_name": "John",
                 "email": "multi@posthog.com",

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -37,7 +37,6 @@ class TestTeamSignup(CloudAPIBaseTest):
         user: User = User.objects.order_by("-pk")[0]
         team: Team = user.teams.first()
         organization: Organization = user.organizations.first()
-        response.data.pop("uuid")
         self.assertEqual(
             response.data,
             {
@@ -247,7 +246,6 @@ class TestTeamSignup(CloudAPIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         user: User = User.objects.order_by("-pk")[0]
-        response.data.pop("uuid")
         self.assertEqual(
             response.data,
             {

--- a/multi_tenancy/urls.py
+++ b/multi_tenancy/urls.py
@@ -1,9 +1,8 @@
 from typing import List
 
-from django.urls import path, re_path
+from django.urls import path
 from posthog.urls import home, opt_slash_path
 from posthog.urls import urlpatterns as posthog_urls
-from posthog.views import login_required
 
 from .views import (
     BillingSubscribeViewset,
@@ -16,28 +15,16 @@ from .views import (
     stripe_billing_portal,
     stripe_checkout_view,
     stripe_webhook,
-    user_with_billing,
 )
 
-# Include `posthog-production` override routes first
+# Include `posthog-cloud` routes first
 urlpatterns: List = [
-    opt_slash_path(
-        "api/user", user_with_billing,
-    ),  # Override to include billing information (included at the top to overwrite main repo `posthog` route)
     opt_slash_path(
         "api/signup", MultiTenancyOrgSignupViewset.as_view(),
     ),  # Override to support setting a billing plan on signup
     opt_slash_path("api/plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
     path("api/plans/<str:key>/template/", plan_template, name="billing_plan_template"),
     path("api/plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
-]
-
-# Include `posthog` default routes, except the home route (to give precendence to billing routes)
-urlpatterns += posthog_urls[:-1]
-
-
-# Include `posthog-production` routes and the home route as fallback
-urlpatterns += [
     opt_slash_path(
         "billing/setup", stripe_checkout_view, name="billing_setup",
     ),  # Redirect to Stripe Checkout to set-up billing (requires session ID)
@@ -55,5 +42,7 @@ urlpatterns += [
     ),  # Page with success message after setting up billing for hosted plans
     opt_slash_path("billing/stripe_webhook", stripe_webhook, name="billing_stripe_webhook"),  # Stripe Webhook
     opt_slash_path("billing/subscribe", BillingSubscribeViewset.as_view({"post": "create"}), name="billing_subscribe"),
-    re_path(r"^.*", login_required(home)),  # Should always be at the very last position
 ]
+
+# Include base `posthog` routes
+urlpatterns += posthog_urls

--- a/multi_tenancy/urls.py
+++ b/multi_tenancy/urls.py
@@ -1,11 +1,12 @@
 from typing import List
 
 from django.urls import path
-from posthog.urls import home, opt_slash_path
+from posthog.urls import opt_slash_path
 from posthog.urls import urlpatterns as posthog_urls
 
 from .views import (
     BillingSubscribeViewset,
+    BillingViewset,
     MultiTenancyOrgSignupViewset,
     PlanViewset,
     billing_failed_view,
@@ -25,6 +26,7 @@ urlpatterns: List = [
     opt_slash_path("api/plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
     path("api/plans/<str:key>/template/", plan_template, name="billing_plan_template"),
     path("api/plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
+    opt_slash_path("api/billing", BillingViewset.as_view({"get": "retrieve"}), name="billing"),
     opt_slash_path(
         "billing/setup", stripe_checkout_view, name="billing_setup",
     ),  # Redirect to Stripe Checkout to set-up billing (requires session ID)

--- a/multi_tenancy/views.py
+++ b/multi_tenancy/views.py
@@ -44,8 +44,12 @@ class PlanViewset(ModelViewSet):
         return queryset
 
 
-class BillingViewset(GenericViewSet):
+class BillingViewset(mixins.RetrieveModelMixin, GenericViewSet):
     serializer_class = BillingSerializer
+
+    def get_object(self) -> OrganizationBilling:
+        instance, _ = OrganizationBilling.objects.get_or_create(organization=self.request.user.organization)
+        return instance
 
 
 class BillingSubscribeViewset(mixins.CreateModelMixin, GenericViewSet):

--- a/multi_tenancy/views.py
+++ b/multi_tenancy/views.py
@@ -5,15 +5,12 @@ from typing import Dict, Optional
 
 import posthoganalytics
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import get_template
-from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from posthog.api.organization import OrganizationSignupViewset
-from posthog.api.user import user
 from posthog.urls import render_template
 from rest_framework import mixins, status
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
@@ -23,9 +20,8 @@ import stripe
 from multi_tenancy.tasks import report_card_validated, update_subscription_billing_period
 
 from .models import OrganizationBilling, Plan
-from .serializers import BillingSubscribeSerializer, MultiTenancyOrgSignupSerializer, PlanSerializer
+from .serializers import BillingSerializer, BillingSubscribeSerializer, MultiTenancyOrgSignupSerializer, PlanSerializer
 from .stripe import cancel_payment_intent, customer_portal_url, parse_webhook, set_default_payment_method_for_customer
-from .utils import get_cached_monthly_event_usage
 
 logger = logging.getLogger(__name__)
 
@@ -48,79 +44,12 @@ class PlanViewset(ModelViewSet):
         return queryset
 
 
+class BillingViewset(GenericViewSet):
+    serializer_class = BillingSerializer
+
+
 class BillingSubscribeViewset(mixins.CreateModelMixin, GenericViewSet):
     serializer_class = BillingSubscribeSerializer
-
-
-def user_with_billing(request: HttpRequest):
-    """
-    Overrides the posthog.api.user.user response to include
-    appropriate billing information in the request
-    """
-
-    response = user(request)
-
-    if response.status_code == 200 and request.user.organization:
-        instance, _ = OrganizationBilling.objects.get_or_create(organization=request.user.organization,)
-
-        output = json.loads(response.content)
-
-        output["billing"] = {
-            "plan": None,
-            "event_allocation": instance.event_allocation,
-        }
-
-        # Obtain event usage of current organization
-        event_usage: Optional[int] = None
-        try:
-            # Function calls clickhouse so make sure Clickhouse failure doesn't block api/user from loading
-            event_usage = get_cached_monthly_event_usage(request.user.organization)
-        except Exception as e:
-            capture_exception(e)
-
-        output["billing"]["current_usage"] = event_usage
-
-        if instance.plan:
-            plan_serializer = PlanSerializer()
-            output["billing"]["plan"] = plan_serializer.to_representation(instance=instance.plan,)
-
-            if instance.should_setup_billing and not instance.is_billing_active:
-
-                if (
-                    instance.stripe_checkout_session
-                    and instance.checkout_session_created_at
-                    and instance.checkout_session_created_at + timezone.timedelta(minutes=1439) > timezone.now()
-                ):
-                    # Checkout session has been created and is still active (i.e. created less than 24 hours ago)
-                    checkout_session = instance.stripe_checkout_session
-                else:
-
-                    try:
-                        (checkout_session, customer_id,) = instance.create_checkout_session(
-                            user=request.user, base_url=request.build_absolute_uri("/"),
-                        )
-                    except ImproperlyConfigured as e:
-                        capture_exception(e)
-                        checkout_session = None
-                    else:
-                        if checkout_session:
-                            OrganizationBilling.objects.filter(pk=instance.pk).update(
-                                stripe_checkout_session=checkout_session,
-                                stripe_customer_id=customer_id,
-                                checkout_session_created_at=timezone.now(),
-                            )
-
-                if checkout_session:
-                    output["billing"] = {
-                        **output["billing"],
-                        "should_setup_billing": True,
-                        "stripe_checkout_session": checkout_session,
-                        "subscription_url": f"/billing/setup?session_id={checkout_session}",
-                    }
-
-        response = JsonResponse(output)
-
-    return response
 
 
 def stripe_checkout_view(request: HttpRequest):


### PR DESCRIPTION
**Builds on** https://github.com/PostHog/posthog/pull/3855. Please review the original PR for full context and motivation, but mainly we keep on our quest to reduce the time it requires for the app to be rendered.

### Details
- This PR removes the cloud overriding of `/api/user/` in favor of an `/api/billing/` endpoint.
- The `/api/billing` endpoint that is introduced incorporates the same information we previously had under the `"billing"` key in the `/api/user` response. Now through a DRF serializer too.
- No logic changes are introduced.