### PR TITLE
Report current $ bill usage

### DIFF
--- a/multi_tenancy/serializers.py
+++ b/multi_tenancy/serializers.py
@@ -71,6 +71,7 @@ class BillingSerializer(serializers.ModelSerializer):
     current_usage = serializers.SerializerMethodField()
     subscription_url = serializers.SerializerMethodField()
     current_bill_amount = serializers.SerializerMethodField()
+    should_display_current_bill = serializers.SerializerMethodField()
 
     class Meta:
         model = OrganizationBilling
@@ -83,6 +84,7 @@ class BillingSerializer(serializers.ModelSerializer):
             "current_usage",
             "subscription_url",
             "current_bill_amount",
+            "should_display_current_bill",
         ]
 
     def get_current_usage(self, instance: OrganizationBilling) -> Optional[int]:
@@ -119,6 +121,11 @@ class BillingSerializer(serializers.ModelSerializer):
                         )
 
         return f"/billing/setup?session_id={checkout_session}" if checkout_session else None
+
+    def get_should_display_current_bill(self, instance: OrganizationBilling) -> bool:
+        if instance.is_billing_active and instance.plan.is_metered_billing:
+            return True
+        return False
 
     def get_current_bill_amount(self, instance: OrganizationBilling) -> Optional[Decimal]:
         """

--- a/multi_tenancy/stripe.py
+++ b/multi_tenancy/stripe.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from decimal import Decimal
 from typing import Any, Dict, Optional, Tuple, Union
 
 from django.conf import settings
@@ -64,13 +65,13 @@ def create_subscription_checkout_session(
     return (session.id, customer_id)
 
 
-def create_zero_auth(email: str, base_url: str, customer_id: str = "",) -> Tuple[str, str]:
+def create_zero_auth(email: str, base_url: str, customer_id: str = "") -> Tuple[str, str]:
 
     customer_id = _get_customer_id(customer_id, email)
 
     payload: Dict = {
         "payment_method_types": ["card"],
-        "line_items": [{"amount": 50, "quantity": 1, "currency": "USD", "name": "Card authorization",},],
+        "line_items": [{"amount": 50, "quantity": 1, "currency": "USD", "name": "Card authorization"}],
         "mode": "payment",
         "payment_intent_data": {
             "capture_method": "manual",
@@ -153,3 +154,14 @@ def report_subscription_item_usage(subscription_item_id: str, billed_usage: int,
 def get_subscription(subscription_id: str) -> Dict[str, Any]:
     _init_stripe()
     return stripe.Subscription.retrieve(subscription_id)
+
+
+def get_current_usage_bill(subscription_id: str) -> Optional[Decimal]:
+    """
+    Obtains the upcoming invoice (not billed yet) for the relevant subscription and parses the
+    zero-decimal amount.
+    """
+    _init_stripe()
+
+    invoice = stripe.Invoice.upcoming(subscription=subscription_id)
+    return Decimal(invoice["amount_due"] / 100) if invoice.get("amount_due") else None

--- a/multi_tenancy/tests/cassettes/test_can_get_bill_usage_for_current_period
+++ b/multi_tenancy/tests/cassettes/test_can_get_bill_usage_for_current_period
@@ -1,0 +1,107 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Stripe/v1 PythonBindings/2.56.0
+    method: GET
+    uri: https://api.stripe.com/v1/invoices/upcoming?subscription=sub_J2i9v9VdhWbjju
+  response:
+    body:
+      string: "{\n  \"object\": \"invoice\",\n  \"account_country\": \"US\",\n  \"account_name\":
+        \"PostHog\",\n  \"account_tax_ids\": null,\n  \"amount_due\": 7823,\n  \"amount_paid\":
+        0,\n  \"amount_remaining\": 0,\n  \"application_fee_amount\": null,\n  \"attempt_count\":
+        0,\n  \"attempted\": false,\n  \"billing_reason\": \"upcoming\",\n  \"charge\":
+        null,\n  \"collection_method\": \"charge_automatically\",\n  \"created\":
+        1619979245,\n  \"currency\": \"usd\",\n  \"custom_fields\": null,\n  \"customer\":
+        \"cus_IuiXChYGDqmHPi\",\n  \"customer_address\": null,\n  \"customer_email\":
+        \"test@posthog.com\",\n  \"customer_name\": null,\n  \"customer_phone\": null,\n
+        \ \"customer_shipping\": null,\n  \"customer_tax_exempt\": \"none\",\n  \"customer_tax_ids\":
+        [\n\n  ],\n  \"default_payment_method\": null,\n  \"default_source\": null,\n
+        \ \"default_tax_rates\": [\n\n  ],\n  \"description\": null,\n  \"discount\":
+        null,\n  \"discounts\": [\n\n  ],\n  \"due_date\": null,\n  \"ending_balance\":
+        0,\n  \"footer\": null,\n  \"last_finalization_error\": null,\n  \"lines\":
+        {\n    \"object\": \"list\",\n    \"data\": [\n      {\n        \"id\": \"il_tmp_17b309EuIatRXSdz71af6143\",\n
+        \       \"object\": \"line_item\",\n        \"amount\": 0,\n        \"currency\":
+        \"usd\",\n        \"description\": \"0 \xD7 Test Product (Tier 1 at $0.0005
+        / month)\",\n        \"discount_amounts\": [\n\n        ],\n        \"discountable\":
+        true,\n        \"discounts\": [\n\n        ],\n        \"livemode\": false,\n
+        \       \"metadata\": {\n        },\n        \"period\": {\n          \"end\":
+        1619978945,\n          \"start\": 1617387005\n        },\n        \"plan\":
+        {\n          \"id\": \"price_1IIt6eEuIatRXSdz0WhjQeI2\",\n          \"object\":
+        \"plan\",\n          \"active\": true,\n          \"aggregate_usage\": \"sum\",\n
+        \         \"amount\": null,\n          \"amount_decimal\": null,\n          \"billing_scheme\":
+        \"tiered\",\n          \"created\": 1612865164,\n          \"currency\": \"usd\",\n
+        \         \"interval\": \"month\",\n          \"interval_count\": 1,\n          \"livemode\":
+        false,\n          \"metadata\": {\n          },\n          \"nickname\": null,\n
+        \         \"product\": \"prod_IuiXiNy8CGzEj7\",\n          \"tiers\": [\n
+        \           {\n              \"flat_amount\": null,\n              \"flat_amount_decimal\":
+        null,\n              \"unit_amount\": null,\n              \"unit_amount_decimal\":
+        \"0.05\",\n              \"up_to\": 1000\n            },\n            {\n
+        \             \"flat_amount\": null,\n              \"flat_amount_decimal\":
+        null,\n              \"unit_amount\": 1,\n              \"unit_amount_decimal\":
+        \"1\",\n              \"up_to\": null\n            }\n          ],\n          \"tiers_mode\":
+        \"graduated\",\n          \"transform_usage\": null,\n          \"trial_period_days\":
+        null,\n          \"usage_type\": \"metered\"\n        },\n        \"price\":
+        {\n          \"id\": \"price_1IIt6eEuIatRXSdz0WhjQeI2\",\n          \"object\":
+        \"price\",\n          \"active\": true,\n          \"billing_scheme\": \"tiered\",\n
+        \         \"created\": 1612865164,\n          \"currency\": \"usd\",\n          \"livemode\":
+        false,\n          \"lookup_key\": null,\n          \"metadata\": {\n          },\n
+        \         \"nickname\": null,\n          \"product\": \"prod_IuiXiNy8CGzEj7\",\n
+        \         \"recurring\": {\n            \"aggregate_usage\": \"sum\",\n            \"interval\":
+        \"month\",\n            \"interval_count\": 1,\n            \"trial_period_days\":
+        null,\n            \"usage_type\": \"metered\"\n          },\n          \"tiers_mode\":
+        \"graduated\",\n          \"transform_quantity\": null,\n          \"type\":
+        \"recurring\",\n          \"unit_amount\": null,\n          \"unit_amount_decimal\":
+        null\n        },\n        \"proration\": false,\n        \"quantity\": 0,\n
+        \       \"subscription\": \"sub_J2i9v9VdhWbjju\",\n        \"subscription_item\":
+        \"si_J2i9eUttdXoSlA\",\n        \"tax_amounts\": [\n\n        ],\n        \"tax_rates\":
+        [\n\n        ],\n        \"type\": \"subscription\"\n      }\n    ],\n    \"has_more\":
+        false,\n    \"total_count\": 1,\n    \"url\": \"/v1/invoices/upcoming/lines?subscription=sub_J2i9v9VdhWbjju\"\n
+        \ },\n  \"livemode\": false,\n  \"metadata\": {\n  },\n  \"next_payment_attempt\":
+        1619982845,\n  \"number\": null,\n  \"on_behalf_of\": null,\n  \"paid\": false,\n
+        \ \"payment_intent\": null,\n  \"payment_settings\": {\n    \"payment_method_options\":
+        null,\n    \"payment_method_types\": null\n  },\n  \"period_end\": 1619979245,\n
+        \ \"period_start\": 1617387245,\n  \"post_payment_credit_notes_amount\": 0,\n
+        \ \"pre_payment_credit_notes_amount\": 0,\n  \"receipt_number\": null,\n  \"starting_balance\":
+        0,\n  \"statement_descriptor\": null,\n  \"status\": \"draft\",\n  \"status_transitions\":
+        {\n    \"finalized_at\": null,\n    \"marked_uncollectible_at\": null,\n    \"paid_at\":
+        null,\n    \"voided_at\": null\n  },\n  \"subscription\": \"sub_J2i9v9VdhWbjju\",\n
+        \ \"subtotal\": 0,\n  \"tax\": null,\n  \"tax_percent\": null,\n  \"total\":
+        0,\n  \"total_discount_amounts\": [\n\n  ],\n  \"total_tax_amounts\": [\n\n
+        \ ],\n  \"transfer_data\": null,\n  \"webhooks_delivered_at\": null\n}\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      access-control-max-age:
+      - '300'
+      cache-control:
+      - no-cache, no-store
+      stripe-version:
+      - '2020-03-02'
+      x-stripe-c-cost:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/multi_tenancy/tests/cassettes/test_failed_request_to_stripe_fails_gracefully
+++ b/multi_tenancy/tests/cassettes/test_failed_request_to_stripe_fails_gracefully
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Stripe/v1 PythonBindings/2.56.0
+    method: GET
+    uri: https://api.stripe.com/v1/invoices/upcoming?subscription=sub_1234567890
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": \"resource_missing\",\n    \"doc_url\":
+        \"https://stripe.com/docs/error-codes/resource-missing\",\n    \"message\":
+        \"No such subscription: 'sub_1234567890'\",\n    \"param\": \"subscription\",\n
+        \   \"type\": \"invalid_request_error\"\n  }\n}\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '246'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      access-control-max-age:
+      - '300'
+      cache-control:
+      - no-cache, no-store
+      stripe-version:
+      - '2020-03-02'
+      x-stripe-c-cost:
+      - '0'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -201,6 +201,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "current_usage": 0,
                 "subscription_url": None,
                 "current_bill_amount": None,
+                "should_display_current_bill": False,
             },
         )
 
@@ -232,6 +233,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "current_usage": 0,
                 "subscription_url": None,
                 "current_bill_amount": None,
+                "should_display_current_bill": False,
             },
         )
 
@@ -263,6 +265,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "current_usage": 3,
                 "subscription_url": None,
                 "current_bill_amount": None,
+                "should_display_current_bill": False,
             },
         )
 
@@ -763,6 +766,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "current_usage": None,  # TODO
                 "subscription_url": None,
                 "current_bill_amount": 78.23,
+                "should_display_current_bill": True,
             },
         )
 
@@ -782,6 +786,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(response.json()["current_bill_amount"], None)
+        self.assertEqual(response.json()["should_display_current_bill"], False)
 
     @vcr.use_cassette(cassette_library_dir="multi_tenancy/tests/cassettes", filter_headers=["authorization"])
     def test_failed_request_to_stripe_fails_gracefully(self):
@@ -800,6 +805,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(response.json()["current_bill_amount"], None)
+        self.assertEqual(response.json()["should_display_current_bill"], True)
 
 
 class PlanAPITestCase(CloudAPIBaseTest):

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -588,6 +588,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "current_usage": 4831,
                 "subscription_url": None,
                 "current_bill_amount": None,
+                "should_display_current_bill": False,
             },
         )
 
@@ -763,7 +764,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "is_billing_active": True,
                 "billing_period_ends": billing_period_ends.isoformat().replace("+00:00", "Z"),
                 "event_allocation": None,
-                "current_usage": None,  # TODO
+                "current_usage": 0,
                 "subscription_url": None,
                 "current_bill_amount": 78.23,
                 "should_display_current_bill": True,

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -199,6 +199,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "event_allocation": None,
                 "current_usage": 0,
                 "subscription_url": None,
+                "current_bill_amount": None,
             },
         )
 
@@ -229,6 +230,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "event_allocation": 7500,
                 "current_usage": 0,
                 "subscription_url": None,
+                "current_bill_amount": None,
             },
         )
 
@@ -259,6 +261,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "event_allocation": None,
                 "current_usage": 3,
                 "subscription_url": None,
+                "current_bill_amount": None,
             },
         )
 
@@ -580,6 +583,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
                 "event_allocation": None,
                 "current_usage": 4831,
                 "subscription_url": None,
+                "current_bill_amount": None,
             },
         )
 
@@ -644,7 +648,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
 
     def test_user_with_no_billing_set_up_cannot_manage_it(self):
 
-        organization, team, user = self.create_org_team_user()
+        organization, _, user = self.create_org_team_user()
         OrganizationBilling.objects.create(
             organization=organization, should_setup_billing=True,
         )
@@ -657,7 +661,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
     @patch("multi_tenancy.stripe._get_customer_id")
     def test_organization_can_enroll_in_self_serve_plan(self, mock_customer_id):
         mock_customer_id.return_value = "cus_000111222"
-        organization, team, user = self.create_org_team_user()
+        organization, _, user = self.create_org_team_user()
         plan = self.create_plan(self_serve=True)
 
         org_billing = OrganizationBilling.objects.create(
@@ -687,7 +691,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
         self, mock_customer_id,
     ):
         mock_customer_id.return_value = "cus_000111222"
-        organization, team, user = self.create_org_team_user()
+        organization, _, user = self.create_org_team_user()
         plan = self.create_plan(self_serve=True)
 
         self.client.force_login(user)
@@ -710,7 +714,7 @@ class TestAPIOrganizationBilling(CloudAPIBaseTest):
         self.assertTrue((timezone.now() - org_billing.checkout_session_created_at).total_seconds() <= 2,)
 
     def test_cannot_enroll_in_non_self_serve_plan(self):
-        organization, team, user = self.create_org_team_user()
+        organization, _, user = self.create_org_team_user()
         plan = self.create_plan(self_serve=False)
 
         org_billing = OrganizationBilling.objects.create(organization=organization)


### PR DESCRIPTION
From user's feedback in the last billing period and @fuziontech's inspiration, we will now show the bill (in $) for your current running period to avoid any surprises.
- This PR introduces the backend changes required for this. Fetching the relevant information from Stripe to show it to the user.﻿
