### PR TITLE
Don't base OrganizationBilling on Organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-deploy
-env
+deploy/
+env/
+venv/
 .env
 *.pyc
 .DS_Store

--- a/multi_tenancy/migrations/0005_organizationbilling.py
+++ b/multi_tenancy/migrations/0005_organizationbilling.py
@@ -44,7 +44,6 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
             },
-            bases=('posthog.organization',),
         ),
         migrations.RunPython(forwards_func, reverse_func),
     ]


### PR DESCRIPTION
`multitenancy.OrganizationBilling` does not inherit from `posthog.Organization` and is only related to it via a OneToOne primary key field, but for some reason the former model was based on the latter in the migration. This has not posed a problem until now, but after upgrading Django to 3.1 in https://github.com/PostHog/posthog/pull/4007 apparently causes migrations to now add a new field `organization_ptr_id`, which the Python model does not actually work with.